### PR TITLE
fix: rewrite coverage.xml source paths for cross-runner compatibility

### DIFF
--- a/.github/workflows/epyon-scan.yml
+++ b/.github/workflows/epyon-scan.yml
@@ -102,6 +102,14 @@ jobs:
           && echo "✅ Coverage artifact downloaded" \
           || echo "⚠️ Coverage artifact not available — SonarQube will run without coverage data"
 
+          # Rewrite absolute <source> paths in coverage.xml so SonarQube can
+          # map them to the checkout directory on this runner.
+          if [[ -f target-repo/coverage.xml ]]; then
+            CHECKOUT_DIR="${{ github.workspace }}/target-repo"
+            echo "🔧 Rewriting coverage.xml source paths → $CHECKOUT_DIR"
+            sed -i -E "s|<source>[^<]+</source>|<source>${CHECKOUT_DIR}</source>|g" target-repo/coverage.xml
+          fi
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
The coverage.xml generated on the self-hosted build runner contains absolute source paths (e.g. `/opt/github-actions-runners/...`) that don't exist on the `ubuntu-latest` runner where SonarQube runs. This causes SonarQube to warn `Invalid directory path` and report no coverage.

After downloading the coverage artifact, this adds a `sed` command to rewrite the `<source>` elements to point to the actual checkout directory on the scan runner.

This was intended to be part of PR #38 but was lost during a force-push/re-create cycle.