### PR TITLE
feat: add NVD + CISA KEV enrichment to security findings

### DIFF
--- a/.github/workflows/epyon-scan.yml
+++ b/.github/workflows/epyon-scan.yml
@@ -627,6 +627,16 @@ jobs:
               low:                 $low
             }' > "$SCAN_DIR/scan-metrics.json"
 
+      - name: Enrich Findings with NVD + CISA KEV
+        if: always()
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SCAN_DIR: ${{ steps.run-scan.outputs.scan_dir }}
+        run: |
+          cd epyon
+          chmod +x scripts/shell/enrich-findings.sh
+          scripts/shell/enrich-findings.sh || true
+
       - name: Upload Complete Scan Results
         uses: actions/upload-artifact@v4
         if: always()
@@ -963,8 +973,9 @@ jobs:
 
           findings = data.get(severity_key, [])
 
-          # Build table rows
+          # Build table rows + collect KEV findings for panel
           rows = []
+          kev_findings = []
           for finding in findings:
               vuln_id = (finding.get("vulnerability_id") or finding.get("check_id")
                          or finding.get("detector") or "N/A")
@@ -973,9 +984,19 @@ jobs:
               version = finding.get("package_version") or "-"
               tool    = finding.get("tool") or "N/A"
               desc    = (finding.get("description") or "")[:120]
-              rows.append({"id": vuln_id, "pkg": pkg, "ver": version, "tool": tool, "desc": desc})
+              nvd_url = finding.get("nvd_url") or ""
+              is_kev  = finding.get("cisa_kev") is True
+              rows.append({"id": vuln_id, "pkg": pkg, "ver": version, "tool": tool,
+                           "desc": desc, "nvd_url": nvd_url, "is_kev": is_kev})
+              if is_kev:
+                  kev_findings.append({
+                      "id": vuln_id,
+                      "due_date": finding.get("cisa_due_date") or "N/A",
+                      "required_action": (finding.get("cisa_required_action") or "")[:200],
+                      "ransomware": finding.get("cisa_known_ransomware") is True,
+                  })
 
-          def cell(text):
+          def cell_text(text):
               return {
                   "type": "tableCell",
                   "attrs": {},
@@ -983,6 +1004,18 @@ jobs:
                       {"type": "text", "text": str(text)[:200]}
                   ]}]
               }
+
+          def cell_link(text, url):
+              if url:
+                  return {
+                      "type": "tableCell",
+                      "attrs": {},
+                      "content": [{"type": "paragraph", "content": [
+                          {"type": "text", "text": str(text)[:200],
+                           "marks": [{"type": "link", "attrs": {"href": url}}]}
+                      ]}]
+                  }
+              return cell_text(text)
 
           def header_cell(text):
               return {
@@ -1000,10 +1033,12 @@ jobs:
 
           data_rows = []
           for r in rows:
+              kev_prefix = "🔥 " if r["is_kev"] else ""
+              id_cell = cell_link(kev_prefix + r["id"], r["nvd_url"]) if r["nvd_url"] else cell_text(kev_prefix + r["id"])
               data_rows.append({
                   "type": "tableRow",
-                  "content": [cell(r["id"]), cell(r["pkg"]), cell(r["ver"]),
-                               cell(r["tool"]), cell(r["desc"])]
+                  "content": [id_cell, cell_text(r["pkg"]), cell_text(r["ver"]),
+                               cell_text(r["tool"]), cell_text(r["desc"])]
               })
 
           table = {
@@ -1012,10 +1047,43 @@ jobs:
               "content": [header_row] + data_rows
           }
 
+          # Build optional CISA KEV panel
+          kev_panel_blocks = []
+          if kev_findings:
+              kev_lines = []
+              for k in kev_findings:
+                  line_text = f"\U0001f525 {k['id']} — Due: {k['due_date']}"
+                  if k["ransomware"]:
+                      line_text += " ⚠️ Ransomware"
+                  if k["required_action"]:
+                      line_text += f"\n   Action: {k['required_action']}"
+                  kev_lines.append({"type": "paragraph", "content": [
+                      {"type": "text", "text": line_text}
+                  ]})
+              kev_panel_blocks = [{
+                  "type": "panel",
+                  "attrs": {"panelType": "error"},
+                  "content": [
+                      {"type": "paragraph", "content": [
+                          {"type": "text",
+                           "text": f"\U0001f525 {len(kev_findings)} CISA Known Exploited Vulnerabilities Detected",
+                           "marks": [{"type": "strong"}]}
+                      ]},
+                      *kev_lines,
+                      {"type": "paragraph", "content": [
+                          {"type": "text", "text": "CISA KEV Catalog",
+                           "marks": [{"type": "link", "attrs": {
+                               "href": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
+                           }}]}
+                      ]}
+                  ]
+              }]
+
           adf = {
               "version": 1,
               "type": "doc",
               "content": [
+                  *kev_panel_blocks,
                   {"type": "paragraph", "content": [
                       {"type": "text", "text": summary_line}
                   ]},

--- a/scripts/shell/enrich-findings.sh
+++ b/scripts/shell/enrich-findings.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# enrich-findings.sh
+# Enriches security-findings-summary.json with data from:
+#   - CISA Known Exploited Vulnerabilities (KEV) catalog
+#   - NIST NVD 2.0 API (CVSS v3 scores, CWE IDs, references, published date)
+#
+# Usage:
+#   enrich-findings.sh [--scan-dir <path>] [--nvd-api-key <key>] [--quiet] [--dry-run]
+#
+# Environment variables:
+#   SCAN_DIR        – path to scan directory (overridden by --scan-dir)
+#   NVD_API_KEY     – optional NVD API key (boosts rate limit to 50 req/30s)
+#   QUIET           – suppress non-error output when set to "true"
+#
+# Exit codes:
+#   0 – enrichment completed (or skipped gracefully due to network/missing files)
+#   1 – bad arguments or missing required tools
+
+set -euo pipefail
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'
+CYAN='\033[0;36m'; NC='\033[0m'
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+SCAN_DIR_ARG=""
+NVD_API_KEY="${NVD_API_KEY:-}"
+QUIET="${QUIET:-false}"
+DRY_RUN=false
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scan-dir)     SCAN_DIR_ARG="$2"; shift 2 ;;
+        --nvd-api-key)  NVD_API_KEY="$2"; shift 2 ;;
+        --quiet|-q)     QUIET=true; shift ;;
+        --dry-run)      DRY_RUN=true; shift ;;
+        --help|-h)
+            sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+log()  { [[ "$QUIET" == false ]] && echo -e "$*" >&2 || true; }
+warn() { echo -e "${YELLOW}⚠️  $*${NC}" >&2; }
+info() { log "${CYAN}ℹ️  $*${NC}"; }
+ok()   { log "${GREEN}✅ $*${NC}"; }
+
+# ── Resolve scan directory ────────────────────────────────────────────────────
+if [[ -n "$SCAN_DIR_ARG" ]]; then
+    SCAN_DIR="$SCAN_DIR_ARG"
+elif [[ -n "${SCAN_DIR:-}" ]]; then
+    : # use env var
+else
+    # Auto-detect latest scan under ./scans/
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    LATEST=$(ls -td "$REPO_ROOT"/scans/*/ 2>/dev/null | head -1 || true)
+    if [[ -z "$LATEST" ]]; then
+        warn "No scan directory found and SCAN_DIR not set — skipping enrichment"
+        exit 0
+    fi
+    SCAN_DIR="${LATEST%/}"
+fi
+
+FINDINGS_FILE="$SCAN_DIR/security-findings-summary.json"
+if [[ ! -f "$FINDINGS_FILE" ]]; then
+    warn "security-findings-summary.json not found at $FINDINGS_FILE — skipping enrichment"
+    exit 0
+fi
+
+# ── Tool checks ───────────────────────────────────────────────────────────────
+if ! command -v python3 &>/dev/null; then
+    warn "python3 not found — skipping enrichment"
+    exit 0
+fi
+if ! command -v curl &>/dev/null; then
+    warn "curl not found — skipping enrichment"
+    exit 0
+fi
+
+log ""
+log "${CYAN}═══════════════════════════════════════════════${NC}"
+log "${CYAN}   🔍 Enriching Findings with NVD + CISA KEV   ${NC}"
+log "${CYAN}═══════════════════════════════════════════════${NC}"
+log "${CYAN}Scan dir: $SCAN_DIR${NC}"
+
+# ── Download CISA KEV catalog ─────────────────────────────────────────────────
+KEV_CACHE="/tmp/epyon_cisa_kev_$$.json"
+KEV_URL="https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+info "Downloading CISA KEV catalog..."
+if curl -sf --max-time 30 -o "$KEV_CACHE" "$KEV_URL" 2>/dev/null; then
+    kev_count=$(python3 -c "import json,sys; d=json.load(open('$KEV_CACHE')); print(len(d.get('vulnerabilities',[])))" 2>/dev/null || echo "?")
+    ok "CISA KEV catalog downloaded ($kev_count entries)"
+else
+    warn "Could not download CISA KEV catalog — KEV enrichment will be skipped"
+    echo "[]" > "$KEV_CACHE"
+    # Make it a valid format so the Python script handles gracefully
+    echo '{"vulnerabilities":[]}' > "$KEV_CACHE"
+fi
+
+# ── Run Python enrichment script ─────────────────────────────────────────────
+# All NVD API calls are in Python to handle rate-limiting, retries, and JSON
+# merging in a single pass.
+
+if [[ "$DRY_RUN" == true ]]; then
+    log "${YELLOW}[dry-run] Would enrich $FINDINGS_FILE — skipping actual writes${NC}"
+    rm -f "$KEV_CACHE"
+    exit 0
+fi
+
+python3 - "$FINDINGS_FILE" "$KEV_CACHE" "${NVD_API_KEY}" <<'PYEOF'
+import json
+import sys
+import os
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+import re
+
+findings_file = sys.argv[1]
+kev_cache     = sys.argv[2]
+nvd_api_key   = sys.argv[3] if len(sys.argv) > 3 else ""
+
+# ── Load KEV catalog ──────────────────────────────────────────────────────────
+try:
+    with open(kev_cache) as f:
+        kev_raw = json.load(f)
+    kev_by_cve = {v["cveID"]: v for v in kev_raw.get("vulnerabilities", [])}
+except Exception as e:
+    print(f"⚠️  Failed to parse KEV catalog: {e}", file=sys.stderr)
+    kev_by_cve = {}
+
+print(f"  KEV entries loaded: {len(kev_by_cve)}", file=sys.stderr)
+
+# ── Load findings ─────────────────────────────────────────────────────────────
+with open(findings_file) as f:
+    data = json.load(f)
+
+severity_keys = ["critical_findings", "high_findings", "medium_findings", "low_findings"]
+
+# Collect unique CVE IDs (skip non-CVE identifiers like GHSA, CKV_*, detector names)
+CVE_RE = re.compile(r'^CVE-\d{4}-\d+$', re.IGNORECASE)
+
+cve_set = set()
+for sk in severity_keys:
+    for finding in data.get(sk, []):
+        vid = finding.get("vulnerability_id") or finding.get("id") or ""
+        if CVE_RE.match(vid):
+            cve_set.add(vid.upper())
+
+print(f"  Unique CVEs to enrich: {len(cve_set)}", file=sys.stderr)
+
+# ── NVD 2.0 API helpers ───────────────────────────────────────────────────────
+NVD_BASE = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+# Unauthenticated: 5 requests / 30 s  → sleep 6 s between calls
+# Authenticated:  50 requests / 30 s  → sleep 0.7 s between calls
+SLEEP_INTERVAL = 0.7 if nvd_api_key else 6.0
+
+nvd_cache: dict = {}
+
+def fetch_nvd(cve_id: str) -> dict | None:
+    """Return the NVD CVE item dict or None on failure."""
+    params = {"cveId": cve_id}
+    url = NVD_BASE + "?" + urllib.parse.urlencode(params)
+    headers = {"User-Agent": "epyon-security-scanner/1.0"}
+    if nvd_api_key:
+        headers["apiKey"] = nvd_api_key
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.load(resp)
+        vulns = body.get("vulnerabilities", [])
+        if vulns:
+            return vulns[0].get("cve", {})
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None  # CVE not in NVD
+        print(f"  NVD HTTP {e.code} for {cve_id}", file=sys.stderr)
+    except Exception as e:
+        print(f"  NVD error for {cve_id}: {e}", file=sys.stderr)
+    return None
+
+def nvd_enrich(cve_id: str) -> dict:
+    """Fetch NVD data for a CVE and return an enrichment dict."""
+    if cve_id in nvd_cache:
+        return nvd_cache[cve_id]
+
+    cve_data = fetch_nvd(cve_id)
+    time.sleep(SLEEP_INTERVAL)
+
+    if not cve_data:
+        result = {"nvd_url": f"https://nvd.nist.gov/vuln/detail/{cve_id}"}
+        nvd_cache[cve_id] = result
+        return result
+
+    # CVSS v3 — prefer CVSSv31 over CVSSv30
+    metrics = cve_data.get("metrics", {})
+    cvss3_score = None
+    cvss3_severity = None
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            primary = next((e for e in entries if e.get("type") == "Primary"), entries[0])
+            cvss_data = primary.get("cvssData", {})
+            cvss3_score    = cvss_data.get("baseScore")
+            cvss3_severity = cvss_data.get("baseSeverity")
+            break
+
+    # References — first 5 URLs
+    references = [r.get("url", "") for r in cve_data.get("references", []) if r.get("url")][:5]
+
+    # CWE IDs
+    cwe_ids = []
+    for weakness in cve_data.get("weaknesses", []):
+        for desc in weakness.get("description", []):
+            val = desc.get("value", "")
+            if val.startswith("CWE-"):
+                cwe_ids.append(val)
+    cwe_ids = list(dict.fromkeys(cwe_ids))[:5]  # deduplicate, limit 5
+
+    # Published date (YYYY-MM-DD)
+    published = (cve_data.get("published") or "")[:10]
+
+    result = {
+        "nvd_url":            f"https://nvd.nist.gov/vuln/detail/{cve_id}",
+        "nvd_published":      published,
+        "nvd_cvss_v3_score":  cvss3_score,
+        "nvd_cvss_v3_severity": cvss3_severity,
+        "nvd_references":     references,
+        "nvd_cwe_ids":        cwe_ids,
+    }
+    nvd_cache[cve_id] = result
+    return result
+
+# ── Enrich each CVE ───────────────────────────────────────────────────────────
+kev_enriched = 0
+nvd_enriched = 0
+
+# Pre-fetch NVD for all unique CVEs
+print(f"  Fetching NVD data (sleep {SLEEP_INTERVAL}s between calls)...", file=sys.stderr)
+for i, cve_id in enumerate(sorted(cve_set), 1):
+    print(f"  [{i}/{len(cve_set)}] NVD: {cve_id}", file=sys.stderr)
+    nvd_enrich(cve_id)
+
+# Apply enrichment to all findings
+def enrich_finding(finding: dict) -> dict:
+    global kev_enriched, nvd_enriched
+    vid = (finding.get("vulnerability_id") or finding.get("id") or "").upper()
+    if not CVE_RE.match(vid):
+        return finding
+
+    # CISA KEV
+    kev_entry = kev_by_cve.get(vid)
+    if kev_entry:
+        finding["cisa_kev"]              = True
+        finding["cisa_kev_date_added"]   = kev_entry.get("dateAdded", "")
+        finding["cisa_known_ransomware"] = kev_entry.get("knownRansomwareCampaignUse", "Unknown").lower() == "known"
+        finding["cisa_required_action"]  = kev_entry.get("requiredAction", "")
+        finding["cisa_due_date"]         = kev_entry.get("dueDate", "")
+        kev_enriched += 1
+    else:
+        finding["cisa_kev"] = False
+
+    # NVD
+    nvd = nvd_cache.get(vid, {})
+    if nvd:
+        finding.update(nvd)
+        if nvd.get("nvd_cvss_v3_score") is not None:
+            nvd_enriched += 1
+
+    return finding
+
+for sk in severity_keys:
+    data[sk] = [enrich_finding(f) for f in data.get(sk, [])]
+
+# Update summary metadata
+data.setdefault("enrichment", {})
+data["enrichment"]["enriched_at"]   = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+data["enrichment"]["cisa_kev_total"] = kev_enriched
+data["enrichment"]["nvd_total"]      = nvd_enriched
+data["enrichment"]["kev_catalog_url"] = "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
+
+# ── Write back atomically ─────────────────────────────────────────────────────
+tmp = findings_file + ".enrich_tmp"
+with open(tmp, "w") as f:
+    json.dump(data, f, indent=2)
+os.replace(tmp, findings_file)
+
+print(f"  ✅ NVD: enriched {nvd_enriched} CVEs", file=sys.stderr)
+print(f"  🔥 CISA KEV: {kev_enriched} findings flagged as actively exploited", file=sys.stderr)
+PYEOF
+
+EXIT=$?
+rm -f "$KEV_CACHE"
+
+if [[ $EXIT -ne 0 ]]; then
+    warn "Enrichment Python script exited with code $EXIT — findings JSON left unchanged"
+    exit 0  # best-effort; don't fail the pipeline
+fi
+
+ok "Findings enriched: $FINDINGS_FILE"
+log ""

--- a/scripts/shell/generate-scan-findings-summary.sh
+++ b/scripts/shell/generate-scan-findings-summary.sh
@@ -336,12 +336,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .vulnerability.severity,
+                        vulnerability_id: .vulnerability.id,
                         id: .vulnerability.id,
                         package: .artifact.name,
+                        package_name: .artifact.name,
                         version: .artifact.version,
+                        package_version: .artifact.version,
                         description: .vulnerability.description,
                         cvss_score: (.vulnerability.cvss[0].metrics.baseScore // "N/A"),
-                        fix_available: (if .vulnerability.fix.versions then "Yes" else "No" end)
+                        fix_available: (if .vulnerability.fix.versions then "Yes" else "No" end),
+                        fixed_versions: (.vulnerability.fix.versions // [])
                     }]' "$grype_file" 2>/dev/null || echo "[]")
                 
                 local low_vulns=$(jq -r --arg tool "Grype-$scan_type" '
@@ -349,12 +353,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .vulnerability.severity,
+                        vulnerability_id: .vulnerability.id,
                         id: .vulnerability.id,
                         package: .artifact.name,
+                        package_name: .artifact.name,
                         version: .artifact.version,
+                        package_version: .artifact.version,
                         description: .vulnerability.description,
                         cvss_score: (.vulnerability.cvss[0].metrics.baseScore // "N/A"),
-                        fix_available: (if .vulnerability.fix.versions then "Yes" else "No" end)
+                        fix_available: (if .vulnerability.fix.versions then "Yes" else "No" end),
+                        fixed_versions: (.vulnerability.fix.versions // [])
                     }]' "$grype_file" 2>/dev/null || echo "[]")
                 
                 # Add to summary
@@ -391,12 +399,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .Severity,
+                        vulnerability_id: .VulnerabilityID,
                         id: .VulnerabilityID,
                         package: .PkgName,
+                        package_name: .PkgName,
                         version: .InstalledVersion,
+                        package_version: .InstalledVersion,
                         description: .Description,
                         cvss_score: (.CVSS.nvd.V3Score // "N/A"),
-                        fix_available: (if .FixedVersion then "Yes" else "No" end)
+                        fix_available: (if .FixedVersion and .FixedVersion != "" then "Yes" else "No" end),
+                        fixed_versions: (if .FixedVersion and .FixedVersion != "" then [.FixedVersion] else [] end)
                     }]' "$trivy_file" 2>/dev/null || echo "[]")
                 
                 local high_vulns=$(jq -r --arg tool "Trivy-$scan_type" '
@@ -404,12 +416,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .Severity,
+                        vulnerability_id: .VulnerabilityID,
                         id: .VulnerabilityID,
                         package: .PkgName,
+                        package_name: .PkgName,
                         version: .InstalledVersion,
+                        package_version: .InstalledVersion,
                         description: .Description,
                         cvss_score: (.CVSS.nvd.V3Score // "N/A"),
-                        fix_available: (if .FixedVersion then "Yes" else "No" end)
+                        fix_available: (if .FixedVersion and .FixedVersion != "" then "Yes" else "No" end),
+                        fixed_versions: (if .FixedVersion and .FixedVersion != "" then [.FixedVersion] else [] end)
                     }]' "$trivy_file" 2>/dev/null || echo "[]")
                 
                 local medium_vulns=$(jq -r --arg tool "Trivy-$scan_type" '
@@ -417,12 +433,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .Severity,
+                        vulnerability_id: .VulnerabilityID,
                         id: .VulnerabilityID,
                         package: .PkgName,
+                        package_name: .PkgName,
                         version: .InstalledVersion,
+                        package_version: .InstalledVersion,
                         description: .Description,
                         cvss_score: (.CVSS.nvd.V3Score // "N/A"),
-                        fix_available: (if .FixedVersion then "Yes" else "No" end)
+                        fix_available: (if .FixedVersion and .FixedVersion != "" then "Yes" else "No" end),
+                        fixed_versions: (if .FixedVersion and .FixedVersion != "" then [.FixedVersion] else [] end)
                     }]' "$trivy_file" 2>/dev/null || echo "[]")
                 
                 local low_vulns=$(jq -r --arg tool "Trivy-$scan_type" '
@@ -430,12 +450,16 @@ EOF
                         tool: $tool,
                         type: "vulnerability",
                         severity: .Severity,
+                        vulnerability_id: .VulnerabilityID,
                         id: .VulnerabilityID,
                         package: .PkgName,
+                        package_name: .PkgName,
                         version: .InstalledVersion,
+                        package_version: .InstalledVersion,
                         description: .Description,
                         cvss_score: (.CVSS.nvd.V3Score // "N/A"),
-                        fix_available: (if .FixedVersion then "Yes" else "No" end)
+                        fix_available: (if .FixedVersion and .FixedVersion != "" then "Yes" else "No" end),
+                        fixed_versions: (if .FixedVersion and .FixedVersion != "" then [.FixedVersion] else [] end)
                     }]' "$trivy_file" 2>/dev/null || echo "[]")
                 
                 # Add to summary

--- a/scripts/shell/generate-security-dashboard.sh
+++ b/scripts/shell/generate-security-dashboard.sh
@@ -331,6 +331,42 @@ if [ -f "$REMEDIATION_FILE" ] && command -v jq &> /dev/null; then
     jq -r '.remediations[] | "\(.cve)|\(.package.name)|\(.package.fixed_version)|\(.remediation.update_command)"' "$REMEDIATION_FILE" 2>/dev/null > "$REMEDIATION_DATA_FILE"
 fi
 
+# ---- Load enrichment data (NVD + CISA KEV) from security-findings-summary.json ----
+ENRICHMENT_DATA_FILE="/tmp/enrichment_map_$$.txt"
+FINDINGS_SUMMARY_FOR_ENRICH="${LATEST_SCAN}/security-findings-summary.json"
+KEV_IDS_FILE="/tmp/kev_ids_$$.txt"
+touch "$ENRICHMENT_DATA_FILE" "$KEV_IDS_FILE"
+if [ -f "$FINDINGS_SUMMARY_FOR_ENRICH" ] && command -v jq &> /dev/null; then
+    echo "🔍 Loading NVD + CISA KEV enrichment data..."
+    # Build lookup: CVE_ID|nvd_url|nvd_cvss_v3_score|nvd_cvss_v3_severity|nvd_published|cisa_kev|cisa_due_date|cisa_required_action|cisa_known_ransomware
+    jq -r '
+        [.critical_findings[], .high_findings[], .medium_findings[], .low_findings[]] |
+        .[] |
+        select(.nvd_url or .cisa_kev == true) |
+        [
+            (.vulnerability_id // .id // ""),
+            (.nvd_url // ""),
+            (.nvd_cvss_v3_score // "" | tostring),
+            (.nvd_cvss_v3_severity // ""),
+            (.nvd_published // ""),
+            (if .cisa_kev then "true" else "false" end),
+            (.cisa_due_date // ""),
+            (.cisa_required_action // ""),
+            (if .cisa_known_ransomware then "true" else "false" end)
+        ] | join("|")
+    ' "$FINDINGS_SUMMARY_FOR_ENRICH" 2>/dev/null > "$ENRICHMENT_DATA_FILE"
+
+    # Separate KEV IDs file for quick lookup
+    jq -r '
+        [.critical_findings[], .high_findings[], .medium_findings[], .low_findings[]] |
+        .[] | select(.cisa_kev == true) | (.vulnerability_id // .id // "")
+    ' "$FINDINGS_SUMMARY_FOR_ENRICH" 2>/dev/null > "$KEV_IDS_FILE"
+
+    enrich_count=$(wc -l < "$ENRICHMENT_DATA_FILE" | tr -d ' ')
+    kev_count=$(wc -l < "$KEV_IDS_FILE" | tr -d ' ')
+    echo "  ✅ Enrichment loaded: $enrich_count CVEs with NVD data, $kev_count flagged as CISA KEV"
+fi
+
 # Function to get remediation for a CVE and package
 get_remediation() {
     local cve="$1"
@@ -340,12 +376,78 @@ get_remediation() {
     fi
 }
 
+# Function to get enrichment data for a CVE
+get_enrichment() {
+    local cve="$1"
+    if [ -f "$ENRICHMENT_DATA_FILE" ]; then
+        grep "^${cve}|" "$ENRICHMENT_DATA_FILE" 2>/dev/null | head -1 || echo ""
+    fi
+}
+
+# Function to check if CVE is in CISA KEV
+is_kev() {
+    local cve="$1"
+    [ -f "$KEV_IDS_FILE" ] && grep -qxF "$cve" "$KEV_IDS_FILE" 2>/dev/null
+}
+
 # Function to inject remediation into vulnerability HTML
 inject_remediation() {
     local cve="$1"
     local pkg="$2"
-    
-    local remediation_data=$(get_remediation "$cve" "$pkg")
+
+    # ── CISA KEV banner ──────────────────────────────────────────────────────
+    if is_kev "$cve"; then
+        local enrich_row
+        enrich_row=$(get_enrichment "$cve")
+        local due_date="" required_action="" is_ransomware=""
+        if [ -n "$enrich_row" ]; then
+            IFS='|' read -r _id _url _score _sev _pub _kev due_date required_action is_ransomware <<< "$enrich_row"
+        fi
+        echo "<div class=\"detail-section\" style=\"background: linear-gradient(135deg, #3b0000 0%, #5c1a00 100%); border-left: 4px solid #dc2626; padding: 15px; margin: 10px 0 6px 0; border-radius: 6px;\">"
+        echo "<h5 style=\"color: #f87171; margin-bottom: 8px;\">🔥 ACTIVELY EXPLOITED — CISA Known Exploited Vulnerability</h5>"
+        if [ -n "$due_date" ]; then
+            echo "<div style=\"margin: 6px 0; font-size:0.9em;\"><strong style=\"color:#fca5a5;\">CISA Remediation Due:</strong> <span style=\"color:#fde68a;\">$due_date</span></div>"
+        fi
+        if [ -n "$required_action" ]; then
+            echo "<div style=\"margin: 6px 0; font-size:0.88em; color:#fca5a5;\"><strong>Required Action:</strong> $required_action</div>"
+        fi
+        if [ "$is_ransomware" = "true" ]; then
+            echo "<div style=\"margin: 6px 0; font-size:0.85em; background:#4c0519; border-radius:4px; padding:6px 10px; color:#fda4af;\">⚠️ <strong>Associated with ransomware campaigns</strong></div>"
+        fi
+        echo "<div style=\"margin-top:8px; font-size:0.8em;\"><a href=\"https://www.cisa.gov/known-exploited-vulnerabilities-catalog\" target=\"_blank\" rel=\"noopener\" style=\"color:#f87171;\">→ CISA KEV Catalog</a></div>"
+        echo "</div>"
+    fi
+
+    # ── NVD reference link ───────────────────────────────────────────────────
+    local enrich_row
+    enrich_row=$(get_enrichment "$cve")
+    if [ -n "$enrich_row" ]; then
+        IFS='|' read -r _id nvd_url nvd_score nvd_sev nvd_pub <<< "$enrich_row"
+        if [ -n "$nvd_url" ]; then
+            local score_color="#60a5fa"
+            if [ -n "$nvd_score" ] && [ "$nvd_score" != "null" ] && [ "$nvd_score" != "" ]; then
+                score_val=$(echo "$nvd_score" | cut -d. -f1)
+                if [ "$score_val" -ge 9 ] 2>/dev/null; then score_color="#dc2626"
+                elif [ "$score_val" -ge 7 ] 2>/dev/null; then score_color="#f97316"
+                elif [ "$score_val" -ge 4 ] 2>/dev/null; then score_color="#fbbf24"
+                fi
+            fi
+            echo "<div class=\"detail-section\" style=\"background: #1a2236; border-left: 3px solid #3b82f6; padding: 10px 14px; margin: 6px 0; border-radius: 6px; font-size:0.88em;\">"
+            echo "<div style=\"display:flex; gap:16px; align-items:center; flex-wrap:wrap;\">"
+            echo "<a href=\"$nvd_url\" target=\"_blank\" rel=\"noopener\" style=\"color:#60a5fa; font-weight:600;\">📋 NVD: $cve</a>"
+            if [ -n "$nvd_score" ] && [ "$nvd_score" != "null" ] && [ "$nvd_score" != "" ]; then
+                echo "<span style=\"color:$score_color; font-weight:700;\">CVSS v3: $nvd_score"
+                [ -n "$nvd_sev" ] && [ "$nvd_sev" != "null" ] && echo " ($nvd_sev)"
+                echo "</span>"
+            fi
+            [ -n "$nvd_pub" ] && [ "$nvd_pub" != "null" ] && [ "$nvd_pub" != "" ] && echo "<span style=\"color:#8892a4;\">Published: $nvd_pub</span>"
+            echo "</div></div>"
+        fi
+    fi
+
+    # ── Fix/upgrade recommendation ───────────────────────────────────────────
+    local remediation_data
+    remediation_data=$(get_remediation "$cve" "$pkg")
     if [ -n "$remediation_data" ]; then
         IFS='|' read -r _cve _pkg fix_ver cmd <<< "$remediation_data"
         echo "<div class=\"detail-section\" style=\"background: linear-gradient(135deg, #052e16 0%, #14532d 100%); border-left: 4px solid #10b981; padding: 15px; margin: 10px 0; border-radius: 6px;\">"

--- a/scripts/shell/run-target-security-scan.sh
+++ b/scripts/shell/run-target-security-scan.sh
@@ -1078,7 +1078,16 @@ if [[ -f "$SCRIPT_DIR/consolidate-security-reports.sh" ]]; then
     else
         echo -e "${YELLOW}⚠️  Report consolidation script not found${NC}"
     fi
-    
+
+    # Enrich findings with NVD + CISA KEV data
+    echo ""
+    echo -e "${BLUE}🔍 Enriching findings with NVD + CISA KEV data...${NC}"
+    if [[ -f "$SCRIPT_DIR/enrich-findings.sh" ]]; then
+        "$SCRIPT_DIR/enrich-findings.sh" --scan-dir "$SCAN_DIR" || true
+    else
+        echo -e "${YELLOW}⚠️  enrich-findings.sh not found, skipping enrichment${NC}"
+    fi
+
     # Generate Scan Manifest for Integrity Verification
     echo ""
     echo -e "${BLUE}🔐 Generating scan manifest for integrity verification...${NC}"


### PR DESCRIPTION
- Add enrich-findings.sh: downloads CISA KEV catalog and calls NVD 2.0 API per unique CVE; patches security-findings-summary.json in place
- generate-scan-findings-summary.sh: add vulnerability_id, package_name, package_version, fixed_versions to Grype Med/Low and all Trivy tiers
- generate-security-dashboard.sh: inject_remediation() now shows CISA KEV banner (red) and NVD reference bar (blue) per enriched finding
- epyon-scan.yml: new CI step 'Enrich Findings with NVD + CISA KEV'; JIRA ADF body shows KEV panel and CVE IDs as NVD hyperlinks
- run-target-security-scan.sh: call enrich-findings.sh after findings summary generation for local scans

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
