### PR TITLE
Stig history

### DIFF
--- a/configuration/monitored-apps.json
+++ b/configuration/monitored-apps.json
@@ -2,6 +2,7 @@
   "comet-starter",
   "epyon",
   "https://github.com/MetroStar/iris.git",
+  "https://github.com/MetroStar/midas.git",
   "iris",
   "midas",
   "sapphire"

--- a/documentation/stig-selection-workflow.drawio
+++ b/documentation/stig-selection-workflow.drawio
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
+  <root>
+    <mxCell id="0" />
+    <mxCell id="1" parent="0" />
+
+    <!-- Title -->
+    <mxCell id="title" value="Epyon — STIG Selection &amp; Execution Workflow (Layer 13)" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="327" y="20" width="1000" height="40" as="geometry" />
+    </mxCell>
+
+    <!-- START -->
+    <mxCell id="start" value="START&#xa;run-stig-scan.sh &lt;TARGET_DIR&gt;" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=13;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="627" y="80" width="240" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- Check SKIP_STIG -->
+    <mxCell id="check_skip" value="SKIP_STIG=true ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="180" width="200" height="80" as="geometry" />
+    </mxCell>
+
+    <!-- Skip exit -->
+    <mxCell id="skip_exit" value="Echo skip message&#xa;exit 0" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="950" y="195" width="160" height="50" as="geometry" />
+    </mxCell>
+
+    <!-- Validate TARGET_DIR -->
+    <mxCell id="validate_target" value="TARGET_DIR exists ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="300" width="200" height="80" as="geometry" />
+    </mxCell>
+
+    <!-- Error: bad target -->
+    <mxCell id="err_target" value="[ERROR] Target not found&#xa;exit 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="950" y="315" width="160" height="50" as="geometry" />
+    </mxCell>
+
+    <!-- STIG Source decision -->
+    <mxCell id="stig_source_q" value="STIGS_FILE set ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="420" width="200" height="80" as="geometry" />
+    </mxCell>
+
+    <!-- Single file mode -->
+    <mxCell id="single_file" value="Single-file mode&#xa;Source = STIGS_FILE&#xa;(.cklb or .xml)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="950" y="435" width="180" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- Directory mode -->
+    <mxCell id="dir_mode" value="Directory mode&#xa;Source = STIGS_DIR&#xa;(default: configuration/stigs/)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="330" y="435" width="200" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- Find STIG files -->
+    <mxCell id="find_files" value="find STIGS_DIR -maxdepth 1&#xa;-name *.cklb -o -name *.xml" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="330" y="540" width="200" height="55" as="geometry" />
+    </mxCell>
+
+    <!-- No files found error -->
+    <mxCell id="no_files" value="0 STIG files found ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="340" y="630" width="180" height="70" as="geometry" />
+    </mxCell>
+
+    <mxCell id="err_no_files" value="[ERROR] No .cklb/.xml files&#xa;exit 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="100" y="645" width="170" height="45" as="geometry" />
+    </mxCell>
+
+    <!-- Pre-flight checks -->
+    <mxCell id="preflight" value="Pre-flight checks&#xa;• python3 available ?&#xa;• openai pkg installed ?&#xa;• OPENAI_API_KEY set ?&#xa;  (warn only — assessment proceeds)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="560" width="260" height="90" as="geometry" />
+    </mxCell>
+
+    <!-- Delegate label -->
+    <mxCell id="delegate_label" value="Delegate to run-stig-assessment.py" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontStyle=2;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="670" width="260" height="30" as="geometry" />
+    </mxCell>
+
+    <!-- Collect source files -->
+    <mxCell id="collect_src" value="Collect source files&#xa;from TARGET_DIR&#xa;(py/ts/js/go/yaml/json/tf…&#xa; Dockerfiles, READMEs…&#xa; skip: node_modules, .venv, dist…)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="720" width="260" height="90" as="geometry" />
+    </mxCell>
+
+    <!-- Build app profile -->
+    <mxCell id="app_profile" value="Build App Profile&#xa;• detect language / framework&#xa;• detect web / session signals&#xa;• detect login routes" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="840" width="260" height="80" as="geometry" />
+    </mxCell>
+
+    <!-- For each STIG file loop label -->
+    <mxCell id="loop_stig_label" value="FOR EACH STIG FILE" style="text;html=1;strokeColor=#6c8ebf;fillColor=#dae8fc;align=center;verticalAlign=middle;fontStyle=1;fontSize=13;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="597" y="950" width="260" height="35" as="geometry" />
+    </mxCell>
+
+    <!-- Parse STIG file -->
+    <mxCell id="parse_stig" value="parse-stig-cklb.py&#xa;Parse STIG file&#xa;• .cklb  → JSON rules array&#xa;• .xml   → XCCDF Group/Rule elements&#xa;→ list of controls with:&#xa;  vuln_id, title, severity,&#xa;  check_content, fix_text, ccis" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1005" width="260" height="110" as="geometry" />
+    </mxCell>
+
+    <!-- Applicability check -->
+    <mxCell id="applicability" value="AI Applicability Check&#xa;(OpenAI — 1 API call)&#xa;STIG name + sample control titles&#xa;vs. App Profile&#xa;→ { applicable: bool, reason }" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1145" width="260" height="85" as="geometry" />
+    </mxCell>
+
+    <!-- Applicable? -->
+    <mxCell id="applicable_q" value="applicable = true ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="1265" width="160" height="70" as="geometry" />
+    </mxCell>
+
+    <!-- Not applicable path -->
+    <mxCell id="not_applicable" value="Mark ALL controls&#xa;'Not Applicable'&#xa;Write stig-results-{slug}.json&#xa;Write findings-{app}-{slug}.md&#xa;Skip to next STIG" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="950" y="1270" width="190" height="80" as="geometry" />
+    </mxCell>
+
+    <!-- Build repo manifest -->
+    <mxCell id="build_manifest" value="Build Repo Manifest&#xa;(full file tree for AI context)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1370" width="260" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- Batch controls -->
+    <mxCell id="batch_loop_label" value="FOR EACH BATCH (BATCH_SIZE controls, default 20)" style="text;html=1;strokeColor=#82b366;fillColor=#d5e8d4;align=center;verticalAlign=middle;fontStyle=1;fontSize=12;rounded=1;" vertex="1" parent="1">
+      <mxGeometry x="557" y="1460" width="340" height="35" as="geometry" />
+    </mxCell>
+
+    <!-- Extract keywords -->
+    <mxCell id="keywords" value="Extract keywords from&#xa;check_content of batch controls&#xa;(stopword-filtered, top 30)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1515" width="260" height="65" as="geometry" />
+    </mxCell>
+
+    <!-- Rank files -->
+    <mxCell id="rank_files" value="Rank source files by keyword hits&#xa;(most relevant files first)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1600" width="260" height="55" as="geometry" />
+    </mxCell>
+
+    <!-- Build code context -->
+    <mxCell id="build_context" value="Build code context&#xa;Fill up to 250 KB budget&#xa;with ranked files&#xa;(higher-scoring files fill first)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1675" width="260" height="75" as="geometry" />
+    </mxCell>
+
+    <!-- Call OpenAI -->
+    <mxCell id="call_openai" value="Call OpenAI API&#xa;System: STIG analyst prompt&#xa;User: manifest + controls JSON + code context&#xa;→ JSON array of assessments:&#xa;  { vuln_id, status, evidence, confidence }" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1770" width="260" height="95" as="geometry" />
+    </mxCell>
+
+    <!-- Delay between batches -->
+    <mxCell id="batch_delay" value="Wait BATCH_DELAY seconds&#xa;(default 1s, rate-limit buffer)&#xa;→ next batch?" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="1885" width="260" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- More batches? -->
+    <mxCell id="more_batches_q" value="More batches ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="1975" width="160" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- Write output -->
+    <mxCell id="write_output" value="Write output files&#xa;• stig-controls-{slug}.json&#xa;• stig-results-{slug}.json&#xa;  (assessments + token_usage)&#xa;• findings-{app}-{slug}.md&#xa;• findings-{app}.md  (primary — first STIG)&#xa;• findings-{app}-{slug}.cklb  (if .cklb source)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="597" y="2065" width="260" height="115" as="geometry" />
+    </mxCell>
+
+    <!-- More STIGs? -->
+    <mxCell id="more_stigs_q" value="More STIG files ?" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="647" y="2210" width="160" height="60" as="geometry" />
+    </mxCell>
+
+    <!-- END -->
+    <mxCell id="end_node" value="END&#xa;All STIGs assessed" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=13;fontStyle=1;" vertex="1" parent="1">
+      <mxGeometry x="647" y="2300" width="160" height="55" as="geometry" />
+    </mxCell>
+
+    <!-- ===== LEGEND ===== -->
+    <mxCell id="legend_box" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1200" y="80" width="220" height="270" as="geometry" />
+    </mxCell>
+    <mxCell id="legend_title" value="LEGEND" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;fontStyle=1;fontSize=13;" vertex="1" parent="1">
+      <mxGeometry x="1200" y="88" width="220" height="25" as="geometry" />
+    </mxCell>
+    <mxCell id="leg1" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="120" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg1t" value="Start / End" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="120" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg2" value="" style="rhombus;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="152" width="30" height="25" as="geometry" />
+    </mxCell>
+    <mxCell id="leg2t" value="Decision / Check" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="155" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="190" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg3t" value="Config / Input selection" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="190" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg4" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="222" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg4t" value="Processing step" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="222" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg5" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="254" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg5t" value="OpenAI API call" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="254" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg6" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="286" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg6t" value="Error / Skip path" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="286" width="155" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg7" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+      <mxGeometry x="1215" y="318" width="30" height="20" as="geometry" />
+    </mxCell>
+    <mxCell id="leg7t" value="Output / Success" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;fontSize=12;" vertex="1" parent="1">
+      <mxGeometry x="1255" y="318" width="155" height="20" as="geometry" />
+    </mxCell>
+
+    <!-- ===== EDGES ===== -->
+
+    <!-- start → check_skip -->
+    <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="start" target="check_skip" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- check_skip → skip_exit (yes) -->
+    <mxCell id="e2" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="check_skip" target="skip_exit" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- check_skip → validate_target (no) -->
+    <mxCell id="e3" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="check_skip" target="validate_target" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- validate_target → err_target (no) -->
+    <mxCell id="e4" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="validate_target" target="err_target" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- validate_target → stig_source_q (yes) -->
+    <mxCell id="e5" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="validate_target" target="stig_source_q" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- stig_source_q → single_file (yes) -->
+    <mxCell id="e6" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="stig_source_q" target="single_file" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- stig_source_q → dir_mode (no) -->
+    <mxCell id="e7" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="stig_source_q" target="dir_mode" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- dir_mode → find_files -->
+    <mxCell id="e8" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="dir_mode" target="find_files" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- find_files → no_files -->
+    <mxCell id="e9" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="find_files" target="no_files" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- no_files → err_no_files (yes — 0 files) -->
+    <mxCell id="e10" value="Yes (0 files)" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="no_files" target="err_no_files" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- no_files → preflight (no — files found) -->
+    <mxCell id="e11" value="No (files found)" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="no_files" target="preflight" parent="1">
+      <mxGeometry relative="1" as="geometry">
+        <Array as="points">
+          <mxPoint x="430" y="710" />
+          <mxPoint x="430" y="605" />
+          <mxPoint x="727" y="605" />
+        </Array>
+      </mxGeometry>
+    </mxCell>
+
+    <!-- single_file → preflight -->
+    <mxCell id="e12" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="single_file" target="preflight" parent="1">
+      <mxGeometry relative="1" as="geometry">
+        <Array as="points">
+          <mxPoint x="1040" y="510" />
+          <mxPoint x="1040" y="605" />
+          <mxPoint x="857" y="605" />
+        </Array>
+      </mxGeometry>
+    </mxCell>
+
+    <!-- preflight → collect_src -->
+    <mxCell id="e13" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="preflight" target="collect_src" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- collect_src → app_profile -->
+    <mxCell id="e14" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="collect_src" target="app_profile" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- app_profile → loop_stig_label -->
+    <mxCell id="e15" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="app_profile" target="loop_stig_label" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- loop_stig_label → parse_stig -->
+    <mxCell id="e16" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="loop_stig_label" target="parse_stig" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- parse_stig → applicability -->
+    <mxCell id="e17" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="parse_stig" target="applicability" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- applicability → applicable_q -->
+    <mxCell id="e18" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="applicability" target="applicable_q" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- applicable_q → not_applicable (no) -->
+    <mxCell id="e19" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="applicable_q" target="not_applicable" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- applicable_q → build_manifest (yes) -->
+    <mxCell id="e20" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="applicable_q" target="build_manifest" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- build_manifest → batch_loop_label -->
+    <mxCell id="e21" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="build_manifest" target="batch_loop_label" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- batch_loop_label → keywords -->
+    <mxCell id="e22" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="batch_loop_label" target="keywords" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- keywords → rank_files -->
+    <mxCell id="e23" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="keywords" target="rank_files" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- rank_files → build_context -->
+    <mxCell id="e24" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="rank_files" target="build_context" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- build_context → call_openai -->
+    <mxCell id="e25" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="build_context" target="call_openai" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- call_openai → batch_delay -->
+    <mxCell id="e26" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="call_openai" target="batch_delay" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- batch_delay → more_batches_q -->
+    <mxCell id="e27" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="batch_delay" target="more_batches_q" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- more_batches_q → batch_loop_label (yes — loop back) -->
+    <mxCell id="e28" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="more_batches_q" target="batch_loop_label" parent="1">
+      <mxGeometry relative="1" as="geometry">
+        <Array as="points">
+          <mxPoint x="480" y="2005" />
+          <mxPoint x="480" y="1477" />
+          <mxPoint x="557" y="1477" />
+        </Array>
+      </mxGeometry>
+    </mxCell>
+
+    <!-- more_batches_q → write_output (no) -->
+    <mxCell id="e29" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="more_batches_q" target="write_output" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- not_applicable → write_output (skips batch loop) -->
+    <mxCell id="e30" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="not_applicable" target="write_output" parent="1">
+      <mxGeometry relative="1" as="geometry">
+        <Array as="points">
+          <mxPoint x="1040" y="1360" />
+          <mxPoint x="1040" y="2122" />
+          <mxPoint x="857" y="2122" />
+        </Array>
+      </mxGeometry>
+    </mxCell>
+
+    <!-- write_output → more_stigs_q -->
+    <mxCell id="e31" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="write_output" target="more_stigs_q" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+    <!-- more_stigs_q → loop_stig_label (yes — loop back) -->
+    <mxCell id="e32" value="Yes" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="more_stigs_q" target="loop_stig_label" parent="1">
+      <mxGeometry relative="1" as="geometry">
+        <Array as="points">
+          <mxPoint x="460" y="2240" />
+          <mxPoint x="460" y="967" />
+          <mxPoint x="597" y="967" />
+        </Array>
+      </mxGeometry>
+    </mxCell>
+
+    <!-- more_stigs_q → end_node (no) -->
+    <mxCell id="e33" value="No" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="more_stigs_q" target="end_node" parent="1">
+      <mxGeometry relative="1" as="geometry" />
+    </mxCell>
+
+  </root>
+</mxGraphModel>

--- a/scripts/shell/run-epyon-scan-ci.sh
+++ b/scripts/shell/run-epyon-scan-ci.sh
@@ -597,7 +597,7 @@ if [[ "${SCAN_MODE:-full}" != "quick" ]] && [[ "${SCAN_MODE:-full}" != "nightly"
   run_group "Layer 13 - STIG Compliance Assessment" \
     env \
       OPENAI_API_KEY="${OPENAI_API_KEY:-}" \
-      OPENAI_MODEL="${OPENAI_MODEL:-gpt-4.1-mini}" \
+      OPENAI_MODEL="${OPENAI_MODEL:-gpt-4o-mini}" \
       SCAN_DIR="$SCAN_DIR" \
       TARGET_DIR="$TARGET_DIR" \
     bash -lc '

--- a/scripts/shell/run-stig-assessment.py
+++ b/scripts/shell/run-stig-assessment.py
@@ -1020,7 +1020,7 @@ def main() -> None:
     parser.add_argument("--target",     required=True, help="Path to application source directory")
     parser.add_argument("--scan-dir",   required=True, help="Path to scan output directory")
     parser.add_argument("--app-name",   required=True, help="Application name for report header")
-    parser.add_argument("--model",      default="gpt-4.1-mini", help="OpenAI model (default: gpt-4.1-mini)")
+    parser.add_argument("--model",      default="gpt-4o-mini", help="OpenAI model (default: gpt-4o-mini)")
     parser.add_argument("--batch-size", type=int, default=BATCH_SIZE_DEFAULT,
                         help=f"Controls per API call (default: {BATCH_SIZE_DEFAULT})")
     parser.add_argument("--delay",      type=float, default=1.0,

--- a/scripts/shell/run-stig-scan.sh
+++ b/scripts/shell/run-stig-scan.sh
@@ -12,7 +12,7 @@
 #
 # Environment variables:
 #   OPENAI_API_KEY    Required. OpenAI API key for LLM assessment.
-#   OPENAI_MODEL      OpenAI model to use (default: gpt-4.1-mini).
+#   OPENAI_MODEL      OpenAI model to use (default: gpt-4o-mini).
 #   STIGS_DIR         Directory of STIG files (default: configuration/stigs).
 #                     Set STIGS_FILE instead to target a single file.
 #   STIGS_FILE        Single STIG file path (overrides STIGS_DIR).
@@ -66,7 +66,7 @@ show_help() {
     echo ""
     echo "Environment variables:"
     echo "  OPENAI_API_KEY    Required. OpenAI API key."
-    echo "  OPENAI_MODEL      Model to use (default: gpt-4.1-mini)."
+    echo "  OPENAI_MODEL      Model to use (default: gpt-4o-mini)."
     echo "  STIGS_DIR         Directory of STIG files (default: configuration/stigs)."
     echo "  STIGS_FILE        Single STIG file path (overrides STIGS_DIR)."
     echo "  SCAN_DIR          Output directory (default: auto-derived scan directory)."
@@ -125,7 +125,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # ── Defaults ─────────────────────────────────────────────────────────────────
 STIGS_DIR="${STIGS_DIR:-${PROJECT_ROOT}/configuration/stigs}"
 STIGS_FILE="${STIGS_FILE:-}"
-OPENAI_MODEL="${OPENAI_MODEL:-gpt-4.1-mini}"
+OPENAI_MODEL="${OPENAI_MODEL:-gpt-4o-mini}"
 BATCH_SIZE="${BATCH_SIZE:-20}"
 BATCH_DELAY="${BATCH_DELAY:-1}"
 APP_NAME="${APP_NAME:-$(basename "$(realpath "$TARGET_DIR")")}"

--- a/tests/shell/test-run-stig-scan.bats
+++ b/tests/shell/test-run-stig-scan.bats
@@ -46,8 +46,8 @@ SCRIPT_PATH="${SCRIPT_DIR}/run-stig-scan.sh"
     grep -q "OPENAI_MODEL" "$SCRIPT_PATH"
 }
 
-@test "run-stig-scan.sh defaults OPENAI_MODEL to gpt-4.1-mini" {
-    grep -q "gpt-4.1-mini" "$SCRIPT_PATH"
+@test "run-stig-scan.sh defaults OPENAI_MODEL to gpt-4o-mini" {
+    grep -q "gpt-4o-mini" "$SCRIPT_PATH"
 }
 
 @test "run-stig-scan.sh supports BATCH_SIZE environment variable" {

--- a/web/api/main.py
+++ b/web/api/main.py
@@ -925,7 +925,10 @@ def get_metrics(response: Response):
                     latest_set.add(fp)
 
         try:
-            latest_dt = datetime.fromisoformat(latest_ts.replace("Z", "+00:00"))
+            _lts = latest_ts.replace("Z", "+00:00")
+            latest_dt = datetime.fromisoformat(_lts)
+            if latest_dt.tzinfo is None:
+                latest_dt = latest_dt.replace(tzinfo=timezone.utc)
         except ValueError:
             continue
 
@@ -933,7 +936,10 @@ def get_metrics(response: Response):
         for fp, first_ts in first_seen.items():
             if fp not in latest_set:
                 try:
-                    first_dt = datetime.fromisoformat(first_ts.replace("Z", "+00:00"))
+                    _fts = first_ts.replace("Z", "+00:00")
+                    first_dt = datetime.fromisoformat(_fts)
+                    if first_dt.tzinfo is None:
+                        first_dt = first_dt.replace(tzinfo=timezone.utc)
                     days = (latest_dt - first_dt).total_seconds() / 86400
                     if days >= 0:
                         all_remediation_days.append(days)
@@ -1118,6 +1124,12 @@ def stig_history(
         ],
         key=lambda s: (s["date"], s["time"]),
     )
+
+    # Deduplicate: keep only the latest STIG scan per calendar date
+    _latest_per_date: dict[str, dict] = {}
+    for s in stig_scans:
+        _latest_per_date[s["date"]] = s
+    stig_scans = list(_latest_per_date.values())
 
     if not stig_scans:
         return {**_base, "apps": stig_apps, "app": selected_app, "slugs": sorted(all_slugs)}

--- a/web/static/app.css
+++ b/web/static/app.css
@@ -465,6 +465,21 @@ body:has(#sidebar:not(.collapsed)) #sidebar-toggle {
   border-radius: 5px;
   font-size: 12.5px;
 }
+.hf-finding-row--clickable {
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.hf-finding-row--clickable:hover {
+  background: var(--bg-active, rgba(255,255,255,0.07));
+}
+.hf-finding-chevron {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  margin-left: auto;
+  opacity: 0.5;
+}
 .hf-finding-sev {
   flex-shrink: 0;
   padding: 1px 7px;

--- a/web/static/app.css
+++ b/web/static/app.css
@@ -2517,6 +2517,19 @@ details[open] > .findings-summary .findings-summary-hint {
 .stig-matrix-cell.na            { background: rgba(255,193,7,0.12);  color: #f0a500; }
 .stig-matrix-cell.not-reviewed  { background: transparent;           color: var(--text-muted); }
 
+/* Status chip used in STIG detail drawer */
+.stig-status-chip {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 9px;
+  border-radius: 10px;
+}
+.stig-status-chip.open          { background: rgba(231,76,60,0.18);  color: #e74c3c; }
+.stig-status-chip.not-a-finding { background: rgba(39,174,96,0.15);  color: #27ae60; }
+.stig-status-chip.na            { background: rgba(255,193,7,0.12);  color: #f0a500; }
+.stig-status-chip.not-reviewed  { background: var(--bg-hover);       color: var(--text-muted); }
+
 /* ── MTTR badge ───────────────────────────────────────────── */
 .mttr-badge {
   display: inline-block;

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -3558,15 +3558,10 @@ async function renderStigHistory(selectedApp, selectedSlug) {
         : `<span class="mttr-badge none">—</span>`;
 
       const latestCls = STATUS_CLASSES[c.latest_status] || 'not-reviewed';
-      const latestScanId = c.timeline.length
-        ? c.timeline[c.timeline.length - 1].scan_id
-        : null;
-      const rowClick = latestScanId
-        ? `onclick="navigate('#/stig-viewer/${encodeURIComponent(latestScanId)}')" style="cursor:pointer"`
-        : '';
+      const cid = _registerStigDetail(c);
 
       return `
-        <tr ${rowClick} title="${latestScanId ? 'Open in STIG Viewer' : ''}">
+        <tr onclick="openStigDetail(${cid})" style="cursor:pointer" title="Click to view details">
           <td class="stig-matrix-sev"><span class="sev-badge ${esc(sevCls)}">${esc(sevCls)}</span></td>
           <td class="stig-matrix-id">${esc(c.vuln_id)}</td>
           <td class="stig-matrix-title" title="${esc(c.title)}">${esc(c.title || '—')}</td>
@@ -4478,6 +4473,112 @@ window.openDependencyDetail = function(did) {
   document.addEventListener('keydown', _onKey);
   drawer._onKey = _onKey;
 };
+
+// ── STIG control detail drawer ────────────────────────────────
+let _stigDetailNextId = 0;
+const _stigDetailRegistry = new Map();
+
+function _registerStigDetail(c) {
+  const id = _stigDetailNextId++;
+  _stigDetailRegistry.set(id, c);
+  return id;
+}
+
+function openStigDetail(id) {
+  const c = _stigDetailRegistry.get(id);
+  if (!c) return;
+  closeFindingDetail();
+
+  const _SC = { 'Open': 'open', 'Not a Finding': 'not-a-finding', 'Not Applicable': 'na', 'Not Reviewed': 'not-reviewed' };
+  const _SA = { 'Open': 'Open', 'Not a Finding': 'Pass', 'Not Applicable': 'N/A', 'Not Reviewed': 'Not Reviewed' };
+
+  const sev     = c.severity || 'unknown';
+  const sevCls  = sev.toLowerCase();
+  const latCls  = _SC[c.latest_status] || 'not-reviewed';
+  const latLbl  = _SA[c.latest_status] || c.latest_status || '—';
+
+  const tl = [...(c.timeline || [])].sort((a, b) => a.date < b.date ? -1 : 1);
+  const timelineRows = tl.map(t => {
+    const cls = _SC[t.status] || 'not-reviewed';
+    const lbl = _SA[t.status] || t.status;
+    return `<tr style="border-bottom:1px solid var(--border-muted)">
+      <td style="padding:5px 10px;font-size:12px;color:var(--text-muted);white-space:nowrap">${esc(t.date.slice(0, 10))}</td>
+      <td style="padding:5px 10px"><span class="stig-status-chip ${cls}">${esc(lbl)}</span></td>
+    </tr>`;
+  }).join('');
+
+  const overlay = document.createElement('div');
+  overlay.className = 'finding-drawer-overlay';
+  overlay.id        = 'finding-drawer-overlay';
+  overlay.addEventListener('click', closeFindingDetail);
+
+  const drawer = document.createElement('div');
+  drawer.className = 'finding-drawer';
+  drawer.id        = 'finding-drawer';
+  drawer.setAttribute('role', 'dialog');
+  drawer.setAttribute('aria-modal', 'true');
+  drawer.setAttribute('aria-label', 'STIG control details');
+  drawer.addEventListener('click', e => e.stopPropagation());
+
+  drawer.innerHTML = `
+    <div class="finding-drawer-header">
+      <div class="finding-drawer-title">
+        <h2>${esc(c.title || c.vuln_id || '—')}</h2>
+        <div class="finding-drawer-badges">
+          <span class="sev-badge ${esc(sevCls)}">${ucFirst(sev)}</span>
+          <span class="tool-tag">STIG</span>
+          <code>${esc(c.vuln_id)}</code>
+        </div>
+      </div>
+      <button class="finding-drawer-close" onclick="closeFindingDetail()" aria-label="Close">✕</button>
+    </div>
+    <div class="finding-drawer-body">
+      <div class="finding-detail-grid">
+        <div class="finding-detail-section">
+          <div class="finding-detail-label">Current Status</div>
+          <div class="finding-detail-value"><span class="stig-status-chip ${latCls}">${esc(latLbl)}</span></div>
+        </div>
+        <div class="finding-detail-section">
+          <div class="finding-detail-label">Benchmark</div>
+          <div class="finding-detail-value">${c.stig_name ? `<code style="font-size:11px">${esc(c.stig_name)}</code>` : '<span style="color:var(--text-dim)">—</span>'}</div>
+        </div>
+        <div class="finding-detail-section">
+          <div class="finding-detail-label">First Open</div>
+          <div class="finding-detail-value">${c.first_open ? esc(c.first_open.slice(0, 10)) : '<span style="color:var(--text-dim)">—</span>'}</div>
+        </div>
+        <div class="finding-detail-section">
+          <div class="finding-detail-label">First Closed</div>
+          <div class="finding-detail-value">${c.first_closed ? esc(c.first_closed.slice(0, 10)) : '<span style="color:var(--text-dim)">—</span>'}</div>
+        </div>
+        <div class="finding-detail-section">
+          <div class="finding-detail-label">MTTR</div>
+          <div class="finding-detail-value">${c.mttr_days != null ? `<strong>${c.mttr_days} days</strong>` : '<span style="color:var(--text-dim)">—</span>'}</div>
+        </div>
+      </div>
+      ${tl.length ? `
+      <div class="finding-detail-section">
+        <div class="finding-detail-label">Scan History</div>
+        <div class="finding-detail-desc" style="padding:0;background:none;border:1px solid var(--border-muted);border-radius:var(--radius);overflow:hidden">
+          <table style="width:100%;border-collapse:collapse">
+            <thead>
+              <tr style="background:var(--bg-hover);border-bottom:1px solid var(--border)">
+                <th style="padding:5px 10px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted);text-align:left">Date</th>
+                <th style="padding:5px 10px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted);text-align:left">Status</th>
+              </tr>
+            </thead>
+            <tbody>${timelineRows}</tbody>
+          </table>
+        </div>
+      </div>` : ''}
+    </div>`;
+
+  document.body.appendChild(overlay);
+  document.body.appendChild(drawer);
+
+  const _onKey = e => { if (e.key === 'Escape') { closeFindingDetail(); document.removeEventListener('keydown', _onKey); } };
+  document.addEventListener('keydown', _onKey);
+  drawer._onKey = _onKey;
+}
 
 // ── Finding detail drawer ─────────────────────────────────────
 function _registerFinding(f) {

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1515,12 +1515,22 @@ function buildModelSecurityCard(scan) {
       ? `<span class="hf-file-checked" title="${esc(mc.file_checked)}">${esc(mc.file_checked.split('/').pop())}</span>`
       : '';
 
-    const mcFindings = (mc.findings || []).map(f => `
-      <div class="hf-finding-row">
+    const mcFindings = (mc.findings || []).map(f => {
+      const fid = _registerFinding({
+        severity:    f.severity || 'medium',
+        id:          f.check || '',
+        tool:        'model card',
+        title:       f.message || f.check || '—',
+        description: f.recommendation || '',
+      });
+      return `
+      <div class="hf-finding-row hf-finding-row--clickable" onclick="openFindingDetail(${fid})" title="Click to view details">
         <span class="hf-finding-sev hf-sev-${esc(f.severity || 'medium')}">${esc(f.severity || 'medium')}</span>
         <span class="hf-finding-file">${esc(f.check || '—')}</span>
         <span class="hf-finding-msg">${esc(f.message || '')}${f.recommendation ? `<span class="hf-recommendation"> → ${esc(f.recommendation)}</span>` : ''}</span>
-      </div>`).join('');
+        <span class="hf-finding-chevron">›</span>
+      </div>`;
+    }).join('');
 
     modelCardSection = `
       <div class="ms-layer ms-layer-border">


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on enhancing the STIG assessment workflow, improving UI/UX for findings and STIG controls, and updating the default OpenAI model used in assessments. The most significant changes are grouped below:

**STIG Assessment and OpenAI Model Updates:**

* Updated the default OpenAI model from `gpt-4.1-mini` to `gpt-4o-mini` across scripts and documentation, ensuring all assessments use the latest model by default. This includes updates in `run-stig-scan.sh`, `run-stig-assessment.py`, and related tests and help messages. [[1]](diffhunk://#diff-3f068d81c04cae25ec4aa6908ab8285974ada1ae8a936e702c93b115c047fa5dL600-R600) [[2]](diffhunk://#diff-bd7229263f6f1b8b8b917521cc7988e597072269bb70121075f36111efc69100L1023-R1023) [[3]](diffhunk://#diff-9c4c3101e011a975604406a4f1dcabed2601bcdef6cfa465bf1160a650bc0f1eL15-R15) [[4]](diffhunk://#diff-9c4c3101e011a975604406a4f1dcabed2601bcdef6cfa465bf1160a650bc0f1eL69-R69) [[5]](diffhunk://#diff-9c4c3101e011a975604406a4f1dcabed2601bcdef6cfa465bf1160a650bc0f1eL128-R128) [[6]](diffhunk://#diff-5c625bebefed6f5dfc5af22ea82fdd19c9160d0190310171c2799bdbb26622e2L49-R50)

**STIG History and Metrics Improvements:**

* In `web/api/main.py`, improved timestamp handling to ensure UTC awareness when parsing dates, and added deduplication logic to keep only the latest STIG scan per calendar date in the STIG history API. [[1]](diffhunk://#diff-546ed09b6dfc229b10fd56356ae890dea323b243ab8d3fcd169b3ea77c5d92ddL928-R942) [[2]](diffhunk://#diff-546ed09b6dfc229b10fd56356ae890dea323b243ab8d3fcd169b3ea77c5d92ddR1128-R1133)

**UI/UX Enhancements for Findings and STIG Controls:**

* Added a clickable row and chevron indicator to model card findings, allowing users to open a detail drawer for each finding. [[1]](diffhunk://#diff-ccc65a460849f6ea85afb12fd50bb51b1bdb5c91ab7fce34e000990b2f9de214R468-R482) [[2]](diffhunk://#diff-950ae170a3b66a807fd799df204c9b87752a0e1248a3291646229a9b278f352aL1518-R1533)
* Implemented a new STIG control detail drawer in the frontend, accessible from the STIG matrix/history table, displaying control details, status chips, and scan history in a user-friendly format. [[1]](diffhunk://#diff-950ae170a3b66a807fd799df204c9b87752a0e1248a3291646229a9b278f352aL3551-R3564) [[2]](diffhunk://#diff-950ae170a3b66a807fd799df204c9b87752a0e1248a3291646229a9b278f352aR4477-R4582)
* Introduced new CSS styles for clickable finding rows, chevrons, and STIG status chips to visually distinguish interactive elements and status indicators. [[1]](diffhunk://#diff-ccc65a460849f6ea85afb12fd50bb51b1bdb5c91ab7fce34e000990b2f9de214R468-R482) [[2]](diffhunk://#diff-ccc65a460849f6ea85afb12fd50bb51b1bdb5c91ab7fce34e000990b2f9de214R2520-R2532)

**Configuration Update:**

* Added the `https://github.com/MetroStar/midas.git` repository to the monitored applications list.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
