### PR TITLE
feat(web): honor OPENAI_MODEL env for AI summaries

### DIFF
--- a/web/api/main.py
+++ b/web/api/main.py
@@ -1322,7 +1322,15 @@ def ai_config_get(response: Response):
     return {
         "key_set":  bool(key),
         "key_hint": masked,
-        "model":    openai_summary.get_model(),
+        # `model` reflects only the UI-managed value so the Settings dropdown
+        # stays in sync with what was actually saved. Returning the resolved
+        # effective model here would surface a non-allowlisted env value (e.g.
+        # gemma4:26b) that the dropdown can't represent; the browser would then
+        # fall back to its first <option> and a subsequent Save would persist
+        # that, clobbering the env-configured model. `active_model` exposes the
+        # resolved model (UI > OPENAI_MODEL > default) for display only.
+        "model":        cfg.get("model") or "gpt-4.1",
+        "active_model": openai_summary.get_model(),
     }
 
 

--- a/web/api/main.py
+++ b/web/api/main.py
@@ -1322,7 +1322,7 @@ def ai_config_get(response: Response):
     return {
         "key_set":  bool(key),
         "key_hint": masked,
-        "model":    cfg.get("model") or "gpt-4.1",
+        "model":    openai_summary.get_model(),
     }
 
 

--- a/web/api/openai_summary.py
+++ b/web/api/openai_summary.py
@@ -32,6 +32,23 @@ def get_api_key() -> str | None:
     return os.environ.get("OPENAI_API_KEY") or None
 
 
+# Default model used when neither the UI config nor the environment specify one.
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+def get_model() -> str:
+    """Resolve the chat model name.
+
+    Precedence (mirrors get_api_key): the UI-managed ai-config.json wins so a
+    value chosen in Settings is honored, then the OPENAI_MODEL environment
+    variable (so deployments such as Quartz can point the web summaries at a
+    self-hosted model like gemma4:26b without touching the UI), and finally a
+    hard-coded default.
+    """
+    cfg = read_ai_config()
+    return cfg.get("model") or os.environ.get("OPENAI_MODEL") or DEFAULT_MODEL
+
+
 # Maps scan_type values to human-readable classification used in prompts.
 _CONTINUOUS_SCAN_TYPES = {"nightly"}
 _EVALUATED_SCAN_LABELS: dict[str, str] = {
@@ -155,8 +172,7 @@ async def generate_summary(scan_id: str, scan_meta: dict, findings: dict) -> str
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     client = AsyncOpenAI(api_key=api_key)
     response = await client.chat.completions.create(
@@ -256,8 +272,7 @@ async def generate_technical_summary(scan_id: str, scan_meta: dict, findings: di
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     client = AsyncOpenAI(api_key=api_key)
     response = await client.chat.completions.create(
@@ -315,8 +330,7 @@ async def generate_global_summary(apps: list[dict]) -> str:
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     continuous, evaluated = _split_apps_by_classification(apps)
 
@@ -377,8 +391,7 @@ async def generate_global_technical_summary(apps: list[dict]) -> str:
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     continuous, evaluated = _split_apps_by_classification(apps)
 
@@ -509,8 +522,7 @@ async def generate_fix_suggestion(finding: dict) -> str:
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     user_msg = (
         "Provide a remediation plan for the following security finding:\n\n"


### PR DESCRIPTION
## Summary

The web executive/technical summary endpoints resolved the chat model **only** from the UI-managed `web/ai-config.json`, falling back to a hard-coded `gpt-4o-mini`. That file lives inside the image filesystem (not on a mounted volume), so a self-hosted deployment cannot durably point the summaries at its own model — a user would have to re-set it via **Settings** after every pod restart.

This PR adds a single `get_model()` helper that resolves the model with the **same precedence as `get_api_key()`**:

1. UI config (`ai-config.json`) — so an explicit Settings choice still wins
2. `OPENAI_MODEL` environment variable — so deployments can configure the model declaratively
3. Hard-coded `DEFAULT_MODEL` fallback

## Changes

- `web/api/openai_summary.py`
  - New `DEFAULT_MODEL` constant + `get_model()` helper.
  - All five summary/fix functions (`generate_summary`, `generate_technical_summary`, `generate_global_summary`, `generate_global_technical_summary`, `generate_fix_suggestion`) now call `get_model()` instead of duplicating the `cfg.get("model") or "gpt-4o-mini"` lookup.
- `web/api/main.py`
  - `GET /api/ai/config` now reports the **actually-active** model via `get_model()`, fixing an inconsistency where it defaulted to `gpt-4.1` while the summaries defaulted to `gpt-4o-mini`.

## Motivation

In [Quartz](https://github.com/MetroStar/quartz), AI inference is served by a self-hosted Ollama model (`gemma4:26b`) behind an OpenAI-compatible `agentgateway`. The deployment already injects `OPENAI_BASE_URL` and `OPENAI_MODEL` via a ConfigMap, but only the STIG CLI path honored `OPENAI_MODEL` — the **web** summaries ignored it and silently fell back to `gpt-4o-mini`. To make that work today, Quartz maintains an Ollama `gpt-4o-mini` alias (`FROM gemma4:26b`) purely so the web summaries resolve to a loaded model. With this change, the web path honors `OPENAI_MODEL`, so that alias can be retired and all components converge on a single resident model name — avoiding loading identical weights twice in GPU memory.

## Notes / scope

- The `POST /api/ai/config` allowlist (`{gpt-4.1, gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4, gpt-3.5-turbo}`) still restricts which names can be **saved from the UI**. The env path intentionally **bypasses** that allowlist so operators retain control of the deployed model without loosening UI input validation. If desired, a follow-up could surface the env-configured model in the Settings dropdown.
- No behavior change for existing OpenAI users: with no `OPENAI_MODEL` set and no UI override, the default remains `gpt-4o-mini`.

## Testing

- `python3 -m py_compile web/api/openai_summary.py web/api/main.py` — passes.
- Precedence verified by inspection: `cfg.get("model")` → `os.environ.get("OPENAI_MODEL")` → `DEFAULT_MODEL`.