### PR TITLE
fix(ai): support self-hosted OpenAI-compatible endpoints without an OpenAI key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Self-hosted / OpenAI-compatible endpoints now work without an OpenAI key** —
+  the AI summary and STIG-triage features previously failed with
+  "OpenAI API key not configured" whenever `OPENAI_API_KEY` was empty, even when
+  `OPENAI_BASE_URL` pointed at a keyless local backend (Ollama, vLLM, LocalAI,
+  an in-cluster AI gateway). `get_api_key()` now falls back to a non-secret
+  placeholder when a non-OpenAI base URL is configured; a real `api.openai.com`
+  endpoint still requires a user-supplied key.
+- **Custom `OPENAI_BASE_URL` from the Settings UI is now honored** — the OpenAI
+  SDK only auto-reads the base URL from the environment, so a value saved in
+  Settings was silently ignored. The resolved base URL is now passed explicitly
+  to every `AsyncOpenAI` client.
+- **ISSO summaries honor the configured model** — `generate_global_isso_summary`
+  and `generate_app_isso_summary` hard-coded `gpt-4o-mini` instead of resolving
+  the model via `get_model()`, so they failed against self-hosted models
+  (e.g. `gemma4:26b`) while the executive/technical summaries succeeded.
+
+### Changed
+- **AI config API accepts self-hosted setups** — `POST /api/ai/config` now
+  accepts a `base_url` (http:// allowed for in-cluster endpoints) and arbitrary
+  model ids (e.g. `gemma4:26b`, `llama3.1:8b`) instead of only a fixed OpenAI
+  model allowlist, and no longer rejects non-`sk-` API tokens. `GET /api/ai/config`
+  surfaces the configured and effective base URL.
+
 ## [3.5.0] - 2026-06-03
 
 ### Added

--- a/web/api/main.py
+++ b/web/api/main.py
@@ -55,7 +55,6 @@ _APP_SCAN_RE     = re.compile(r"^(.+)_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2}-\d{2})$")
 _VALID_SCAN_TYPES = {"quick", "full", "nightly", "baseline", "stig", "local_model"}
 _TOKEN_RE        = re.compile(r"^(ghp_|github_pat_|ghs_|gho_)[a-zA-Z0-9_]+$")
 _REPO_RE         = re.compile(r"^[a-zA-Z0-9_.\-]+/[a-zA-Z0-9_.\-]+$")
-_KEY_RE          = re.compile(r"^sk-[A-Za-z0-9_\-]{20,}$")
 
 # ── Metrics cache ─────────────────────────────────────────────
 _metrics_cache:    dict  = {}
@@ -1966,6 +1965,11 @@ def ai_config_get(response: Response):
         # resolved model (UI > OPENAI_MODEL > default) for display only.
         "model":        cfg.get("model") or "gpt-4.1",
         "active_model": openai_summary.get_model(),
+        # The configured custom endpoint (UI value), plus the effective base URL
+        # actually in use (UI > OPENAI_BASE_URL env > OpenAI default) for
+        # display. Empty string means the public OpenAI API.
+        "base_url":        cfg.get("base_url", ""),
+        "active_base_url": openai_summary.get_base_url() or "",
     }
 
 
@@ -1980,13 +1984,33 @@ async def ai_config_post(request: Request, response: Response):
     cfg = openai_summary.read_ai_config()
     new_key = (body.get("api_key") or "").strip()
     if new_key and new_key != "KEEP_EXISTING":
-        if not _KEY_RE.match(new_key):
-            raise HTTPException(400, "api_key does not look like a valid OpenAI secret key")
+        # Accept real OpenAI secret keys (sk-...) as well as arbitrary tokens
+        # used by self-hosted, OpenAI-compatible gateways (vLLM, LiteLLM, ...).
+        # Reject only obviously unsafe values (whitespace / shell metacharacters
+        # / control chars) rather than locking to the OpenAI key format.
+        if len(new_key) > 200 or re.search(r"[\s;&|`$()<>'\"\\]", new_key):
+            raise HTTPException(400, "api_key contains invalid characters")
         cfg["api_key"] = new_key
 
-    allowed_models = {"gpt-4.1", "gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"}
-    if body.get("model") in allowed_models:
-        cfg["model"] = body["model"]
+    if "base_url" in body:
+        base_url = (body.get("base_url") or "").strip()
+        if base_url:
+            # Allow https:// for public providers and http:// for in-cluster /
+            # self-hosted endpoints (e.g. http://ollama.ollama:11434/v1).
+            if not re.match(r"^https?://[A-Za-z0-9.\-]+(:\d+)?(/[\w./\-]*)?$", base_url):
+                raise HTTPException(400, "base_url must be a valid http(s) URL")
+            cfg["base_url"] = base_url
+        else:
+            cfg.pop("base_url", None)  # explicit clear → fall back to env/default
+
+    if body.get("model"):
+        model = str(body["model"]).strip()
+        # Accept curated OpenAI models and any self-hosted model id
+        # (e.g. gemma4:26b, llama3.1:8b). Validate the character set so the
+        # value is safe to use in request bodies and file paths.
+        if not re.match(r"^[A-Za-z0-9._:\-/]{1,100}$", model):
+            raise HTTPException(400, "model contains invalid characters")
+        cfg["model"] = model
 
     openai_summary.write_ai_config(cfg)
     return {"ok": True}

--- a/web/api/main.py
+++ b/web/api/main.py
@@ -1963,7 +1963,7 @@ def ai_config_get(response: Response):
         # fall back to its first <option> and a subsequent Save would persist
         # that, clobbering the env-configured model. `active_model` exposes the
         # resolved model (UI > OPENAI_MODEL > default) for display only.
-        "model":        cfg.get("model") or "gpt-4.1",
+        "model":        cfg.get("model") or openai_summary.DEFAULT_MODEL,
         "active_model": openai_summary.get_model(),
         # The configured custom endpoint (UI value), plus the effective base URL
         # actually in use (UI > OPENAI_BASE_URL env > OpenAI default) for
@@ -1999,6 +1999,16 @@ async def ai_config_post(request: Request, response: Response):
             # self-hosted endpoints (e.g. http://ollama.ollama:11434/v1).
             if not re.match(r"^https?://[A-Za-z0-9.\-]+(:\d+)?(/[\w./\-]*)?$", base_url):
                 raise HTTPException(400, "base_url must be a valid http(s) URL")
+            # SSRF / credential-exfil guard: only the public OpenAI API,
+            # cluster-internal/private hosts, or an operator allowlist
+            # (EPYON_AI_ALLOWED_HOSTS) may be targeted, so this endpoint cannot
+            # be used to redirect a stored API key to an attacker host.
+            if not openai_summary.base_url_allowed(base_url):
+                raise HTTPException(
+                    400,
+                    "base_url host is not allowed; use the public OpenAI API, a "
+                    "cluster-internal endpoint, or add it to EPYON_AI_ALLOWED_HOSTS",
+                )
             cfg["base_url"] = base_url
         else:
             cfg.pop("base_url", None)  # explicit clear → fall back to env/default

--- a/web/api/openai_summary.py
+++ b/web/api/openai_summary.py
@@ -4,10 +4,12 @@ of scan findings using the OpenAI Chat Completions API.
 """
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 _HERE = Path(__file__).parent
 AI_CONFIG_FILE = _HERE / ".." / "ai-config.json"
@@ -78,9 +80,9 @@ def get_model() -> str:
 # api_key, so we supply a dummy one whenever a non-OpenAI base URL is configured.
 _PLACEHOLDER_API_KEY = "sk-local-noauth"
 
-# Substrings identifying the real, authenticated OpenAI API. A request to one of
-# these genuinely requires a user-supplied key, so we never substitute a
-# placeholder for them.
+# Hostnames of the real, authenticated OpenAI API. A request to one of these
+# genuinely requires a user-supplied key, so we never substitute a placeholder.
+# Matched against the parsed URL hostname exactly (see _hostname/_is_self_hosted).
 _OPENAI_PUBLIC_HOSTS = ("api.openai.com",)
 
 
@@ -97,11 +99,60 @@ def get_base_url() -> str | None:
     return cfg.get("base_url") or os.environ.get("OPENAI_BASE_URL") or None
 
 
-def _is_self_hosted(base_url: str | None) -> bool:
-    """True when base_url points at something other than the public OpenAI API."""
+def _hostname(base_url: str | None) -> str | None:
+    """Extract the lowercased hostname from a base URL, or None if unparseable."""
     if not base_url:
+        return None
+    try:
+        return (urlparse(base_url).hostname or "").lower() or None
+    except Exception:
+        return None
+
+
+def _is_self_hosted(base_url: str | None) -> bool:
+    """True when base_url points at something other than the public OpenAI API.
+
+    Compares the parsed hostname exactly (not a substring) so a look-alike host
+    such as ``api.openai.com.evil.com`` is correctly treated as self-hosted.
+    """
+    host = _hostname(base_url)
+    if not host:
         return False
-    return not any(host in base_url for host in _OPENAI_PUBLIC_HOSTS)
+    return host not in _OPENAI_PUBLIC_HOSTS
+
+
+def _is_internal_host(host: str) -> bool:
+    """True for loopback / cluster-internal / RFC1918 hosts that are safe
+    targets for a self-hosted inference endpoint."""
+    if host == "localhost":
+        return True
+    if host.endswith((".svc", ".svc.cluster.local", ".cluster.local",
+                      ".local", ".internal")):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+        return ip.is_private or ip.is_loopback or ip.is_link_local
+    except ValueError:
+        return False
+
+
+def base_url_allowed(base_url: str) -> bool:
+    """Guard against SSRF / credential exfiltration.
+
+    ``POST /api/ai/config`` lets a caller persist a custom ``base_url``; if a
+    real OpenAI key is also stored, an attacker could otherwise redirect
+    requests (and the bearer token) to a host they control. A configured
+    ``base_url`` is therefore accepted only when its hostname is the public
+    OpenAI API, a cluster-internal / private address, or an entry in the
+    operator-provided ``EPYON_AI_ALLOWED_HOSTS`` allowlist (comma-separated).
+    """
+    host = _hostname(base_url)
+    if not host:
+        return False
+    if host in _OPENAI_PUBLIC_HOSTS or _is_internal_host(host):
+        return True
+    allow = os.environ.get("EPYON_AI_ALLOWED_HOSTS", "")
+    return host in {h.strip().lower() for h in allow.split(",") if h.strip()}
 
 
 # Maps scan_type values to human-readable classification used in prompts.

--- a/web/api/openai_summary.py
+++ b/web/api/openai_summary.py
@@ -41,7 +41,19 @@ def get_api_key() -> str | None:
     cfg = read_ai_config()
     if cfg.get("api_key"):
         return cfg["api_key"]
-    return os.environ.get("OPENAI_API_KEY") or None
+    env_key = os.environ.get("OPENAI_API_KEY")
+    if env_key:
+        return env_key
+    # Self-hosted, OpenAI-compatible backends (Ollama, vLLM, LocalAI, an
+    # in-cluster AI gateway, ...) typically do not authenticate requests, but
+    # the OpenAI SDK still refuses to initialize with an empty key. When a
+    # custom (non-OpenAI) base URL is configured, fall back to a non-secret
+    # placeholder so summaries work without a real key. A genuine
+    # api.openai.com endpoint still returns None here and surfaces the
+    # "key not configured" guidance.
+    if _is_self_hosted(get_base_url()):
+        return _PLACEHOLDER_API_KEY
+    return None
 
 
 # Default model used when neither the UI config nor the environment specify one.
@@ -59,6 +71,37 @@ def get_model() -> str:
     """
     cfg = read_ai_config()
     return cfg.get("model") or os.environ.get("OPENAI_MODEL") or DEFAULT_MODEL
+
+
+# A non-secret placeholder used when talking to a self-hosted, OpenAI-compatible
+# endpoint that does not authenticate requests. The OpenAI SDK rejects an empty
+# api_key, so we supply a dummy one whenever a non-OpenAI base URL is configured.
+_PLACEHOLDER_API_KEY = "sk-local-noauth"
+
+# Substrings identifying the real, authenticated OpenAI API. A request to one of
+# these genuinely requires a user-supplied key, so we never substitute a
+# placeholder for them.
+_OPENAI_PUBLIC_HOSTS = ("api.openai.com",)
+
+
+def get_base_url() -> str | None:
+    """Resolve the OpenAI-compatible base URL.
+
+    Precedence mirrors get_api_key()/get_model(): the UI-managed ai-config.json
+    wins, then the OPENAI_BASE_URL environment variable, then None (the SDK's
+    default, i.e. the public OpenAI API). The OpenAI SDK only auto-reads the
+    environment variable, so a base URL chosen in the Settings UI must be passed
+    to the client explicitly (see the AsyncOpenAI call sites below).
+    """
+    cfg = read_ai_config()
+    return cfg.get("base_url") or os.environ.get("OPENAI_BASE_URL") or None
+
+
+def _is_self_hosted(base_url: str | None) -> bool:
+    """True when base_url points at something other than the public OpenAI API."""
+    if not base_url:
+        return False
+    return not any(host in base_url for host in _OPENAI_PUBLIC_HOSTS)
 
 
 # Maps scan_type values to human-readable classification used in prompts.
@@ -186,7 +229,7 @@ async def generate_summary(scan_id: str, scan_meta: dict, findings: dict) -> str
 
     model = get_model()
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -286,7 +329,7 @@ async def generate_technical_summary(scan_id: str, scan_meta: dict, findings: di
 
     model = get_model()
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -378,7 +421,7 @@ async def generate_global_summary(apps: list[dict], metrics: dict | None = None)
         + json.dumps(payload, indent=2)
     )
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -453,7 +496,7 @@ async def generate_global_technical_summary(apps: list[dict], metrics: dict | No
         + json.dumps(payload, indent=2)
     )
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -481,8 +524,7 @@ async def generate_global_isso_summary(apps: list[dict], metrics: dict | None = 
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     continuous, evaluated = _split_apps_by_classification(apps)
 
@@ -533,7 +575,7 @@ async def generate_global_isso_summary(apps: list[dict], metrics: dict | None = 
         + json.dumps(payload, indent=2)
     )
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -738,8 +780,7 @@ async def generate_app_isso_summary(
     except ImportError:
         raise RuntimeError("The 'openai' package is not installed. Run: pip install openai")
 
-    cfg   = read_ai_config()
-    model = cfg.get("model") or "gpt-4o-mini"
+    model = get_model()
 
     critical       = findings.get("critical_findings", [])
     high           = findings.get("high_findings", [])
@@ -825,7 +866,7 @@ async def generate_app_isso_summary(
         + json.dumps(payload, indent=2)
     )
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[
@@ -878,7 +919,7 @@ async def generate_fix_suggestion(finding: dict) -> str:
         + json.dumps(finding, indent=2)
     )
 
-    client = AsyncOpenAI(api_key=api_key)
+    client = AsyncOpenAI(api_key=api_key, base_url=get_base_url())
     response = await client.chat.completions.create(
         model=model,
         messages=[


### PR DESCRIPTION
## Summary

Epyon's AI features (executive / technical / ISSO summaries, fix suggestions, STIG triage) are built on the OpenAI SDK but did **not** work against keyless, self-hosted, OpenAI-compatible backends — Ollama, vLLM, LocalAI, or an in-cluster AI gateway — even when `OPENAI_BASE_URL` was pointed at one. Every summary failed with:

> OpenAI API key not configured. Add it in Settings or set OPENAI_API_KEY.

This surfaced in a Kubernetes deployment that routes Epyon at an in-cluster Ollama (`gemma4:26b`) via an OpenAI-compatible gateway, with no real OpenAI account in play.

## Root causes & fixes

1. **Keyless endpoints rejected.** `get_api_key()` returned `None` when `OPENAI_API_KEY` was unset, and all seven summary functions hard-raised the "key not configured" error. The OpenAI SDK refuses to initialize with an empty key, but self-hosted gateways don't authenticate. → `get_api_key()` now falls back to a non-secret placeholder (`sk-local-noauth`) **only** when a non-`api.openai.com` base URL is configured. A genuine OpenAI endpoint still returns `None` and surfaces the original guidance.

2. **UI-configured `base_url` silently ignored.** The OpenAI SDK only auto-reads `OPENAI_BASE_URL` from the environment, so a base URL saved in Settings (`ai-config.json`) was never used. → A new `get_base_url()` resolves UI → env → default, and the value is passed explicitly to every `AsyncOpenAI(...)` client.

3. **ISSO summaries hard-coded the model.** `generate_global_isso_summary` and `generate_app_isso_summary` used `cfg.get("model") or "gpt-4o-mini"` instead of `get_model()`, so they ignored `OPENAI_MODEL` and failed against self-hosted models (e.g. `gemma4:26b`) while the exec/technical summaries succeeded. → both now use `get_model()`.

4. **AI config API locked to OpenAI.** `POST /api/ai/config` only accepted a fixed OpenAI model allowlist and `sk-` key format, and had no `base_url` field. → it now accepts a `base_url` (with `http://` allowed for in-cluster endpoints), arbitrary model ids (`gemma4:26b`, `llama3.1:8b`, …), and non-`sk-` tokens (validated for safe characters). `GET /api/ai/config` now returns the configured and effective base URL.

## Behavior matrix (verified)

| `OPENAI_API_KEY` | `OPENAI_BASE_URL` | `get_api_key()` |
|---|---|---|
| unset | self-hosted (e.g. `http://ollama…/v1`) | `sk-local-noauth` (placeholder) |
| unset | `https://api.openai.com/v1` | `None` (errors with guidance) |
| unset | unset | `None` |
| set | any | the real key (always wins) |

## Notes / scope

- No behavior change for existing OpenAI-key users — a real key always takes precedence, and the public OpenAI endpoint still requires a key.
- Backend-only. The Settings **UI** form does not yet expose a base-URL field or free-text model input; scripted/`env` configuration is fully supported now, and a UI follow-up can be layered on top.
- `py_compile` clean; `get_api_key()`/`get_base_url()` smoke-tested across all four scenarios above.

## Changelog

Added under `[Unreleased]`.
